### PR TITLE
chore: update OIDC userinfo env vars

### DIFF
--- a/src/helm/env.d/dev/values.impress.yaml.gotmpl
+++ b/src/helm/env.d/dev/values.impress.yaml.gotmpl
@@ -31,8 +31,8 @@ backend:
     LOGGING_LEVEL_HANDLERS_CONSOLE: ERROR
     LOGGING_LEVEL_LOGGERS_ROOT: INFO
     LOGGING_LEVEL_LOGGERS_APP: INFO
-    USER_OIDC_FIELD_TO_SHORTNAME: "given_name"
-    USER_OIDC_FIELDS_TO_FULLNAME: "given_name,usual_name"
+    OIDC_USERINFO_FULLNAME_FIELDS: "given_name,usual_name"
+    OIDC_USERINFO_SHORTNAME_FIELD: "given_name"
     OIDC_OP_JWKS_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/certs
     OIDC_OP_AUTHORIZATION_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/auth
     OIDC_OP_TOKEN_ENDPOINT: https://keycloak.127.0.0.1.nip.io/realms/impress/protocol/openid-connect/token


### PR DESCRIPTION
## Purpose

Rename env vars defining OIDC fields to use for full and short name.
The existing fields give the following warning:

```
2025-05-16 13:34:42,173 core.authentication.backends WARNING USER_OIDC_FIELDS_TO_FULLNAME has been renamed to OIDC_USERINFO_FULLNAME_FIELDS please update your settings.                                                                                                                                                                             
2025-05-16 13:34:42,173 core.authentication.backends WARNING USER_OIDC_FIELD_TO_SHORTNAME has been renamed to OIDC_USERINFO_SHORTNAME_FIELD please update your settings.      
```

